### PR TITLE
Extend square user icons to include DMs on the sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To apply them, **paste them in Settings -> Appearance -> Custom CSS.**
 [class^="TypingIndicator__Base-sc-"] > div > [class^="avatars"] > img {
 	border-radius: 3px;
 }
-
+[data-item-index="0"] [class^="ItemContainer-sc-176t3v5-0"] foreignObject :is(div, img) { border-radius: 3px !important;}
 ```
 
 ## Square server icons (and more)

--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ To apply them, **paste them in Settings -> Appearance -> Custom CSS.**
 [class^="TypingIndicator__Base-sc-"] > div > [class^="avatars"] > img {
 	border-radius: 3px;
 }
-[data-item-index="0"] [class^="ItemContainer-sc-176t3v5-0"] foreignObject :is(div, img) { border-radius: 3px !important;}
+[data-item-index="0"] [class^="ItemContainer-sc-176t3v5-0"] foreignObject :is(div, img) {
+	border-radius: 3px !important;
+}
 ```
 
 ## Square server icons (and more)


### PR DESCRIPTION
actual code by @amycatgirl 

notice how the server icons are still circles, only the user avatars are affected
![preview](https://github.com/lo-kiss/revolt-tweaks/assets/26941050/9e6ab918-9b82-4149-868a-d4c960b06dad)
